### PR TITLE
Cache pos ids

### DIFF
--- a/src/model/attn.py
+++ b/src/model/attn.py
@@ -9,7 +9,6 @@ from rotary_embedding_torch import RotaryEmbedding
 from .nn import rms_norm, NoCastModule
 
 
-
 class RoPE(NoCastModule):
     def __init__(self, config):
         super().__init__()

--- a/src/model/world_model.py
+++ b/src/model/world_model.py
@@ -43,7 +43,8 @@ class PromptEncoder(nn.Module):
             max_length=128
         ).to(self.encoder.device)
         emb = self.encode(inputs).to(self.dtype)
-        return emb * inputs["attention_mask"].unsqueeze(-1).type_as(emb)
+        pad_mask = inputs["attention_mask"].eq(0)
+        return emb, pad_mask
 
 
 def rms_norm(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Profile
- GEMM + GEMM-related + nvfp4 overhead: ~64%
- FlexAttention + Blockmask construction: ~27%
- ~~pos_id construction: 2%~~
- fused rmsnorm / permute: ~2%
- kv cache read/write: ~1%
- RoPE: ~2%
- other: ~4%

Optimization surface summary:
- GEMM:
  - quantization and quant overhead reduction
- FlexAttention:
  - Working FP8
  - FA4 on B200
  - FlashInfer?
- BlockMask:
  - return blockmask of None after all slots filled (might be impossible)
- pos_id construction:
  - cache pos_id, mutate t_pos in place
- fused rmsnorm / permute:
  - already near-optimal
- kv cache read/write:
  - already near-optimal
- RoPE:
  - unsloth RoPE kernel (not viable without re-training)

# Changes:
- **cache pos_id, mutate t_pos in place**: 2.1% throughput increase


### Baseline:
```
-------------------------------------------------------------------------------------------- benchmark: 6 tests -------------------------------------------------------------------------------------------
Name (time in ms)                    Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_ar_rollout[1-True]          14.1034 (1.0)         14.2952 (1.0)         14.1348 (1.0)       0.0420 (1.0)         14.1254 (1.0)       0.0173 (1.0)           2;3  70.7473 (1.0)          20           1
test_img_decoder_only            54.7859 (3.88)        58.6534 (4.10)        57.2618 (4.05)      1.5846 (37.76)       57.9851 (4.11)      2.2168 (128.28)        1;0  17.4637 (0.25)          5           1
test_ar_rollout[4-True]          56.1752 (3.98)        56.9382 (3.98)        56.6033 (4.00)      0.2216 (5.28)        56.6507 (4.01)      0.2418 (13.99)         6;0  17.6668 (0.25)         20           1
test_ar_rollout[16-True]        231.5489 (16.42)      241.7797 (16.91)      235.6720 (16.67)     4.3542 (103.76)     233.0288 (16.50)     8.6959 (503.19)        7;0   4.2432 (0.06)         20           1
test_ar_rollout[64-True]      1,004.9709 (71.26)    1,020.1501 (71.36)    1,013.0038 (71.67)     4.5747 (109.01)   1,012.8942 (71.71)     7.8595 (454.79)        7;0   0.9872 (0.01)         20           1
test_ar_rollout[256-True]     4,297.9972 (304.75)   4,401.0014 (307.87)   4,362.4306 (308.63)   29.8293 (710.83)   4,368.2274 (309.25)   42.6551 (>1000.0)       6;0   0.2292 (0.00)         20           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### baseline plus **cache pos_id, mutate t_pos in place**
```
-------------------------------------------------------------------------------------------- benchmark: 6 tests -------------------------------------------------------------------------------------------
Name (time in ms)                    Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_ar_rollout[1-True]          14.0445 (1.0)         14.2521 (1.0)         14.0767 (1.0)       0.0457 (1.0)         14.0602 (1.0)       0.0260 (1.0)           2;2  71.0392 (1.0)          20           1
test_img_decoder_only            54.1408 (3.85)        57.4367 (4.03)        56.1964 (3.99)      1.3655 (29.87)       56.7067 (4.03)      2.0732 (79.68)         1;0  17.7947 (0.25)          5           1
test_ar_rollout[4-True]          56.3435 (4.01)        56.6646 (3.98)        56.5401 (4.02)      0.1277 (2.79)        56.6038 (4.03)      0.2557 (9.83)          6;0  17.6866 (0.25)         20           1
test_ar_rollout[16-True]        229.9061 (16.37)      230.1559 (16.15)      229.9780 (16.34)     0.0630 (1.38)       229.9567 (16.36)     0.0674 (2.59)          4;1   4.3482 (0.06)         20           1
test_ar_rollout[64-True]        980.7839 (69.83)      991.5645 (69.57)      984.9471 (69.97)     3.6180 (79.13)      984.4831 (70.02)     6.0215 (231.43)        7;0   1.0153 (0.01)         20           1
test_ar_rollout[256-True]     4,176.4810 (297.37)   4,332.9608 (304.02)   4,269.8782 (303.33)   50.6858 (>1000.0)  4,276.4981 (304.16)   86.0134 (>1000.0)       8;0   0.2342 (0.00)         20           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


# Didn't work

### Slightly reduced throughput: preallocate x1 noise

<details>

```
modified   src/world_engine.py
@@ -62,6 +62,7 @@ class WorldEngine:
         # State
         self.kv_cache = StaticKVCache(self.model_cfg, batch_size=1, dtype=dtype).to(device)
         self.frame_ts = torch.tensor([[0]], dtype=torch.long, device=device)
+        self._noise = torch.empty(self.frm_shape, device=self.device, dtype=self.dtype)
         # Static input context tensors
         self._ctx = {
             "button": torch.zeros((1, 1, self.model_cfg.n_buttons), device=device, dtype=dtype),
@@ -92,7 +93,7 @@ class WorldEngine:

     @torch.inference_mode()
     def gen_frame(self, ctrl: CtrlInput = None, return_img: bool = True):
-        x = torch.randn(self.frm_shape, device=self.device, dtype=self.dtype)
+        x = self._noise.normal_()
         inputs = self._prep_inputs(x=x, ctrl=ctrl)
         x0 = self._denoise_pass(x, inputs, self.kv_cache).clone()
         self._cache_pass(x0, inputs, self.kv_cache)
```

</details>

### No change in throughput, added complexity: Generate blockmask once, reuse until new pos_ids

<details>

```
diff --git a/src/model/attn.py b/src/model/attn.py
index 52c2b57..57f34bd 100644
--- a/src/model/attn.py
+++ b/src/model/attn.py
@@ -96,7 +96,7 @@ class Attn(nn.Module):
             self.gate_proj = nn.Linear(self.n_heads, self.n_heads, bias=False)  # sparse attn gate
             nn.init.zeros_(self.gate_proj.weight)

-    def forward(self, x, pos_ids, v1, kv_cache):
+    def forward(self, x, pos_ids, v1, kv_cache, block_mask):
         # Q, K, V proj -> QK-norm -> RoPE
         q = eo.rearrange(self.q_proj(x), "b t (h d) -> b h t d", h=self.n_heads, d=self.d_head)
         k = eo.rearrange(self.k_proj(x), "b t (h d) -> b h t d", h=self.n_kv_heads, d=self.d_head)
@@ -110,10 +110,10 @@ class Attn(nn.Module):
         q, k = self.rope(q, pos_ids), self.rope(k, pos_ids)

         # Update KV-cache in-place
-        k, v, bm = kv_cache.upsert(k, v, pos_ids, self.layer_idx)
+        k, v = kv_cache.upsert(k, v, pos_ids, self.layer_idx)

         # SDPA -> Attention Gate -> Out Proj
-        y = flex_attention(q, k, v, block_mask=bm, enable_gqa=self.enable_gqa)
+        y = flex_attention(q, k, v, block_mask=block_mask, enable_gqa=self.enable_gqa)
         if self.gated_attn:
             gates = torch.sigmoid(self.gate_proj(x[..., :self.n_heads]))
             y = y * gates.permute(0, 2, 1).unsqueeze(-1)
diff --git a/src/model/kv_cache.py b/src/model/kv_cache.py
index a488903..4b6f113 100644
--- a/src/model/kv_cache.py
+++ b/src/model/kv_cache.py
@@ -9,7 +9,7 @@ from torch.nn.attention.flex_attention import (
 )


-def make_block_mask(T: int, L: int, written: torch.Tensor) -> BlockMask:
+def make_block_mask(T: int, L: int, written: torch.Tensor, B: int, Hq: int) -> BlockMask:
     """
     T: Q length for this frame
     L: KV capacity == written.numel()
@@ -22,27 +22,23 @@ def make_block_mask(T: int, L: int, written: torch.Tensor) -> BlockMask:
     # [KV_blocks, BS]
     written_blocks = torch.nn.functional.pad(written, (0, KV_blocks * BS - L)).view(KV_blocks, BS)

-    # Block-level occupancy
-    block_any = written_blocks.any(-1)    # block has at least one written token
-    block_all = written_blocks.all(-1)    # block is fully written
+    block_any = written_blocks.any(-1)      # [KV_blocks]
+    block_all = written_blocks.all(-1)      # [KV_blocks]
+    partial_row = block_any & ~block_all    # [KV_blocks] (needs mask_mod)

-    # Every Q-block sees the same KV-block pattern
-    nonzero_bm = block_any[None, :].expand(Q_blocks, KV_blocks)       # [Q_blocks, KV_blocks]
-    full_bm = block_all[None, :].expand_as(nonzero_bm)                # [Q_blocks, KV_blocks]
-    partial_bm = nonzero_bm & ~full_bm                                # [Q_blocks, KV_blocks]
-
-    def dense_to_ordered(dense_mask: torch.Tensor):
-        # dense_mask: [Q_blocks, KV_blocks] bool
-        # returns: [1,1,Q_blocks], [1,1,Q_blocks,KV_blocks]
-        num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)        # [Q_blocks]
-        indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
-        return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+    def row_to_ordered(mask_row: torch.Tensor):
+        # mask_row: [KV_blocks] bool
+        num = mask_row.sum(dtype=torch.int32)  # scalar
+        order = mask_row.argsort(descending=True, stable=True).to(torch.int32)  # [KV_blocks]
+        kv_num_blocks = num.expand(Q_blocks)[None, None].expand(B, Hq, Q_blocks).contiguous()
+        kv_indices = order.expand(Q_blocks, KV_blocks)[None, None].expand(B, Hq, Q_blocks, KV_blocks).contiguous()
+        return kv_num_blocks, kv_indices

     # Partial blocks (need mask_mod)
-    kv_num_blocks, kv_indices = dense_to_ordered(partial_bm)
+    kv_num_blocks, kv_indices = row_to_ordered(partial_row)

     # Full blocks (mask_mod can be skipped entirely)
-    full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+    full_kv_num_blocks, full_kv_indices = row_to_ordered(block_all)

     def mask_mod(b, h, q, kv):
         return written[kv]
@@ -95,6 +91,28 @@ class LayerKVCache(nn.Module):
         self.frame_offsets = nn.Buffer(torch.arange(self.tpf, dtype=torch.long), persistent=False)
         self.current_idx = nn.Buffer(self.frame_offsets + L, persistent=False)

+    def build_block_mask(self, pos_ids: TensorDict, q_heads: int) -> BlockMask:
+        """
+        Build a head-shaped BlockMask for the current frame for this layer's cache geometry.
+        Mask logic matches the prior behavior: if this step would overwrite a ring bucket,
+        treat that bucket as unreadable for this frame.
+        """
+        T = self.tpf
+        frame_t = pos_ids["t_pos"][0, 0]
+
+        bucket = (frame_t + (self.pinned_dilation - 1)) // self.pinned_dilation
+        slot = bucket % self.num_buckets
+        base = slot * T  # contiguous in [0, L)
+
+        write_step = (frame_t.remainder(self.pinned_dilation) == 0)
+        ring_idx = self.frame_offsets + base
+        mask_written = self.written.clone()
+        # If write_step==True -> clear the would-be-overwritten ring bucket; else no-op.
+        mask_written[ring_idx] = mask_written[ring_idx] & ~write_step
+
+        B = int(self.kv.size(1))
+        return make_block_mask(T, self.capacity, mask_written, B=B, Hq=q_heads)
+
     def reset(self):
         self.kv.zero_()
         self.written.zero_()
@@ -137,9 +155,6 @@ class LayerKVCache(nn.Module):
         self.kv.index_copy_(3, self.current_idx, kv)

         write_step = (frame_t.remainder(self.pinned_dilation) == 0)
-        mask_written = self.written.clone()
-        mask_written[ring_idx] = mask_written[ring_idx] & ~write_step
-        bm = make_block_mask(T, self.capacity, mask_written)

         # Persist current frame into the ring for future queries when unfrozen.
         if not is_frozen:
@@ -149,7 +164,7 @@ class LayerKVCache(nn.Module):
             self.written[dst] = True

         k, v = self.kv.unbind(0)
-        return k, v, bm
+        return k, v


 class StaticKVCache(nn.Module):
@@ -163,6 +178,11 @@ class StaticKVCache(nn.Module):

         period = config.global_attn_period
         off = getattr(config, "global_attn_offset", 0) % period
+
+        is_global = [((i - off) % period == 0) for i in range(config.n_layers)]
+        self._global_ref = next(i for i, g in enumerate(is_global) if g)
+        self._local_ref = next(i for i, g in enumerate(is_global) if not g)
+
         self.layers = nn.ModuleList([
             LayerKVCache(
                 batch_size,
@@ -186,6 +206,16 @@ class StaticKVCache(nn.Module):
     def set_frozen(self, is_frozen: bool):
         self._is_frozen = is_frozen

+    def get_block_masks(self, pos_ids: TensorDict, q_heads: int):
+        """
+        Build head-shaped BlockMasks once per forward for:
+          - local cache geometry
+          - global cache geometry
+        """
+        bm_global = self.layers[self._global_ref].build_block_mask(pos_ids, q_heads=q_heads)
+        bm_local = self.layers[self._local_ref].build_block_mask(pos_ids, q_heads=q_heads)
+        return bm_local, bm_global
+
     def upsert(self, k: Tensor, v: Tensor, pos_ids: TensorDict, layer: int):
         kv = torch.stack([k, v], dim=0)
         return self.layers[layer].upsert(kv, pos_ids, self._is_frozen)
diff --git a/src/model/world_model.py b/src/model/world_model.py
index fb59d46..62dfa21 100644
--- a/src/model/world_model.py
+++ b/src/model/world_model.py
@@ -148,7 +148,7 @@ class WorldDiTBlock(nn.Module):
         do_ctrl_cond = layer_idx % config.ctrl_conditioning_period == 0
         self.ctrl_mlpfusion = MLPFusion(config) if do_ctrl_cond else None

-    def forward(self, x, pos_ids, cond, ctx, v, kv_cache=None):
+    def forward(self, x, pos_ids, cond, ctx, v, kv_cache, block_mask):
         """
         0) Causal Frame Attention
         1) Frame->CTX Cross Attention
@@ -159,7 +159,7 @@ class WorldDiTBlock(nn.Module):
         # Self / Causal Attention
         residual = x
         x = ada_rmsnorm(x, s0, b0)
-        x, v = self.attn(x, pos_ids, v, kv_cache=kv_cache)
+        x, v = self.attn(x, pos_ids, v, kv_cache=kv_cache, block_mask=block_mask)
         x = ada_gate(x, g0) + residual

         # Cross Attention Prompt Conditioning
@@ -193,10 +193,16 @@ class WorldDiT(nn.Module):
         for blk in self.blocks[1:]:
             blk.attn.rope = ref_rope

-    def forward(self, x, pos_ids, cond, ctx, kv_cache=None):
+        period = config.global_attn_period
+        off = getattr(config, "global_attn_offset", 0) % period
+        self._is_global = [((i - off) % period == 0) for i in range(config.n_layers)]
+
+    def forward(self, x, pos_ids, cond, ctx, kv_cache):
+        bm_local, bm_global = kv_cache.get_block_masks(pos_ids, q_heads=self.config.n_heads)
         v = None
         for i, block in enumerate(self.blocks):
-            x, v = block(x, pos_ids, cond, ctx, v, kv_cache=kv_cache)
+            bm = bm_global if self._is_global[i] else bm_local
+            x, v = block(x, pos_ids, cond, ctx, v, kv_cache=kv_cache, block_mask=bm)
         return x


diff --git a/src/patch_model.py b/src/patch_model.py
index 945f82e..300cb12 100644
--- a/src/patch_model.py
+++ b/src/patch_model.py
@@ -111,7 +111,7 @@ class MergedQKVAttn(Attn):

         del self.q_proj, self.k_proj, self.v_proj

-    def forward(self, x, pos_ids, v1, kv_cache):
+    def forward(self, x, pos_ids, v1, kv_cache, block_mask):
         q, k, v = self.qkv_proj(x).split((self.q_out, self.kv_out, self.kv_out), dim=-1)

         B, T = x.shape[:2]
@@ -126,9 +126,9 @@ class MergedQKVAttn(Attn):
         q, k = rms_norm(q), rms_norm(k)
         q, k = self.rope(q, pos_ids), self.rope(k, pos_ids)

-        k, v, bm = kv_cache.upsert(k, v, pos_ids, self.layer_idx)
+        k, v = kv_cache.upsert(k, v, pos_ids, self.layer_idx)

-        y = flex_attention(q, k, v, block_mask=bm, enable_gqa=self.enable_gqa)
+        y = flex_attention(q, k, v, block_mask=block_mask, enable_gqa=self.enable_gqa)

         if self.gated_attn:
             gates = torch.sigmoid(self.gate_proj(x[..., : self.n_heads]))
```

</details>


## Explicitly ignore mask_mod if possible
No throughput improvement. Compiler probably already does this implicitly.

<details>

```
modified   src/model/kv_cache.py
@@ -19,6 +19,25 @@ def make_block_mask(T: int, L: int, written: torch.Tensor) -> BlockMask:
     KV_blocks = (L + BS - 1) // BS
     Q_blocks = (T + BS - 1) // BS

+    # Fast path - only if mask mod is unnecessary
+    if (T % BS == 0) and (L % BS == 0):
+        full = written.view(KV_blocks, BS).all(-1)  # [KV_blocks]
+        m = full.to(torch.int32)
+        n = m.sum(dtype=torch.int32)  # scalar
+        dest = torch.where(full, m.cumsum(0) - 1, n + (1 - m).cumsum(0) - 1).to(torch.int64)
+        idx = torch.empty(KV_blocks, device=written.device, dtype=torch.int32)
+        idx.scatter_(0, dest, torch.arange(KV_blocks, device=written.device, dtype=torch.int32))
+        full_n = n.expand(Q_blocks)[None, None].contiguous()               # [1,1,Q_blocks]
+        full_i = idx.expand(Q_blocks, KV_blocks)[None, None].contiguous()  # [1,1,Q_blocks,KV_blocks]
+        return BlockMask.from_kv_blocks(
+            torch.zeros_like(full_n), full_i,  # no partial blocks
+            full_n, full_i,
+            BLOCK_SIZE=BS,
+            mask_mod=None,
+            seq_lengths=(T, L),
+            compute_q_blocks=False,
+        )
+
```

</details>
