### PR TITLE
Use torch==2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.5.0"
 requires-python = ">=3.10"
 dependencies = [
   "taehv @ https://github.com/madebyollin/taehv/archive/7dc60ec6601af2e668e31bc70acc4cb3665e4c22.zip",
-  "torch==2.10.0",
+  "torch==2.11.0",
   "einops",
   "tensordict==0.10.0",
   "transformers>=5.3.0",


### PR DESCRIPTION
- torch 2.11
- remove unused accelerate dependency
- triton-windows (untested) documentation suggests compatibility